### PR TITLE
replace Type::free_vars with Type::vars

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,16 +257,16 @@ impl<N: Name> TypeSchema<N> {
     ///
     /// [`Variable`]: type.Variable.html
     /// [`TypeSchema`]: enum.TypeSchema.html
-    pub fn free_vars(&self, ctx: &Context<N>) -> Vec<Variable> {
+    pub fn free_vars(&self) -> Vec<Variable> {
         let mut s = HashSet::new();
-        self.free_vars_internal(ctx, &mut s);
+        self.free_vars_internal(&mut s);
         s.into_iter().collect()
     }
-    fn free_vars_internal(&self, ctx: &Context<N>, s: &mut HashSet<Variable>) {
+    fn free_vars_internal(&self, s: &mut HashSet<Variable>) {
         match *self {
             TypeSchema::Monotype(ref t) => t.vars_internal(s),
             TypeSchema::Polytype { variable, ref body } => {
-                body.free_vars_internal(ctx, s);
+                body.free_vars_internal(s);
                 s.remove(&variable);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,7 +623,8 @@ impl<N: Name> Type<N> {
     /// let t = tp!(@arrow[tp!(0), tp!(1)]);
     /// assert_eq!(format!("{}", &t), "t0 → t1");
     ///
-    /// let vs_computed = t.vars();
+    /// let mut vs_computed = t.vars();
+    /// vs_computed.sort();
     /// let vs_expected = vec![0, 1];
     ///
     /// assert_eq!(vs_computed, vs_expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ impl<N: Name> Type<N> {
         }
         t
     }
-    /// Compute all the variables in a type.
+    /// Compute all the variables present in a type.
     ///
     /// # Examples
     ///
@@ -625,9 +625,8 @@ impl<N: Name> Type<N> {
     ///
     /// let mut vs_computed = t.vars();
     /// vs_computed.sort();
-    /// let vs_expected = vec![0, 1];
     ///
-    /// assert_eq!(vs_computed, vs_expected);
+    /// assert_eq!(vs_computed, vec![0, 1]);
     /// # }
     /// ```
     pub fn vars(&self) -> Vec<Variable> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -589,16 +589,16 @@ impl<N: Name> Type<N> {
     /// let mut ctx = Context::default();
     /// ctx.extend(0, tp!(int));
     ///
-    /// let t_gen = t.apply(&ctx).generalize(vec![]);
+    /// let t_gen = t.apply(&ctx).generalize(&[]);
     /// assert_eq!(format!("{}", t_gen), "∀t1. int → t1");
     ///
-    /// let t_gen = t.apply(&ctx).generalize(vec![1]);
+    /// let t_gen = t.apply(&ctx).generalize(&[1]);
     /// assert_eq!(format!("{}", t_gen), "int → t1");
     /// # }
     /// ```
     ///
     /// [`TypeSchema`]: enum.TypeSchema.html
-    pub fn generalize(&self, bound: Vec<Variable>) -> TypeSchema<N> {
+    pub fn generalize(&self, bound: &[Variable]) -> TypeSchema<N> {
         let fvs = self.vars()
             .into_iter()
             .filter(|x| !bound.contains(x))


### PR DESCRIPTION
The concept of free variables is confusing for monotypes (there are no bound variables), so I've removed `Type::free_vars` and replaced it with `Type::vars`. I've also adjusted `Type::generalize` and `TypeSchema::free_vars`, which depended on `Type::free_vars`.

I haven't bumped the version at all. Should I bump it to 4.3.0?