### PR TITLE
add sacred variables to Context::merge, cargo fmt

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,8 +648,7 @@ impl<N: Name> Type<N> {
                 let args = args.iter().map(|t| t.apply(ctx)).collect();
                 Type::Constructed(name.clone(), args)
             }
-            Type::Variable(v) => ctx
-                .substitution
+            Type::Variable(v) => ctx.substitution
                 .get(&v)
                 .cloned()
                 .unwrap_or_else(|| Type::Variable(v)),
@@ -664,8 +663,7 @@ impl<N: Name> Type<N> {
                 t.apply_mut(ctx)
             },
             Type::Variable(v) => {
-                *self = ctx
-                    .substitution
+                *self = ctx.substitution
                     .get(&v)
                     .cloned()
                     .unwrap_or_else(|| Type::Variable(v));
@@ -698,8 +696,7 @@ impl<N: Name> Type<N> {
     ///
     /// [`TypeSchema`]: enum.TypeSchema.html
     pub fn generalize(&self, bound: &[Variable]) -> TypeSchema<N> {
-        let fvs = self
-            .vars()
+        let fvs = self.vars()
             .into_iter()
             .filter(|x| !bound.contains(x))
             .collect::<Vec<Variable>>();
@@ -848,8 +845,7 @@ impl<N: Name> From<VecDeque<Type<N>>> for Type<N> {
 }
 impl<N: Name> From<Vec<Type<N>>> for Type<N> {
     fn from(mut tps: Vec<Type<N>>) -> Type<N> {
-        let mut beta = tps
-            .pop()
+        let mut beta = tps.pop()
             .unwrap_or_else(|| panic!("cannot create a type from nothing"));
         while let Some(alpha) = tps.pop() {
             beta = Type::arrow(alpha, beta)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,8 +39,7 @@ impl<N: Name> Parser<N> {
         constructed_simple<Parser<N>, CompleteStr, Type<N>>,
         self,
         do_parse!(
-            name_raw: alpha
-                >> name: expr_res!(N::parse(&name_raw))
+            name_raw: alpha >> name: expr_res!(N::parse(&name_raw))
                 >> (Type::Constructed(name, vec![]))
         )
     );

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,8 @@ impl<N: Name> Parser<N> {
         constructed_simple<Parser<N>, CompleteStr, Type<N>>,
         self,
         do_parse!(
-            name_raw: alpha >> name: expr_res!(N::parse(&name_raw))
+            name_raw: alpha
+                >> name: expr_res!(N::parse(&name_raw))
                 >> (Type::Constructed(name, vec![]))
         )
     );


### PR DESCRIPTION
There are a couple random formatting changes to make `cargo fmt --all -- --check` happy, but the main change here is to add what I'm calling *sacred* variables to `Context::merge` and thereby to `ContextChange`.

These sacred variables are not touched during reification but keep their original identities, allowing you to, for example, induce constraints between two `Context`s during merging. This is helpful, for instance, when merging two `Context`s whose early history is shared but whose later history is different and should be reified accordingly.