### PR TITLE
Polytype parser: swap order of alternatives to favor bindings over monotypes

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,7 +85,7 @@ impl<N: Name> Parser<N> {
                     call_m!(self.constructed_simple))
         );
     method!(polytype<Parser<N>, CompleteStr, TypeSchema<N>>, mut self,
-               alt!(map!(call_m!(self.monotype), TypeSchema::Monotype) |
-                    call_m!(self.binding))
+            alt!(call_m!(self.binding) |
+                 map!(call_m!(self.monotype), TypeSchema::Monotype))
         );
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,7 +39,8 @@ impl<N: Name> Parser<N> {
         constructed_simple<Parser<N>, CompleteStr, Type<N>>,
         self,
         do_parse!(
-            name_raw: alpha >> name: expr_res!(N::parse(&name_raw))
+            name_raw: alpha
+                >> name: expr_res!(N::parse(&name_raw))
                 >> (Type::Constructed(name, vec![]))
         )
     );

--- a/src/types.rs
+++ b/src/types.rs
@@ -461,7 +461,8 @@ impl<N: Name> Type<N> {
                 let args = args.iter().map(|t| t.apply(ctx)).collect();
                 Type::Constructed(name.clone(), args)
             }
-            Type::Variable(v) => ctx.substitution
+            Type::Variable(v) => ctx
+                .substitution
                 .get(&v)
                 .cloned()
                 .unwrap_or_else(|| Type::Variable(v)),
@@ -476,7 +477,8 @@ impl<N: Name> Type<N> {
                 t.apply_mut(ctx)
             },
             Type::Variable(v) => {
-                *self = ctx.substitution
+                *self = ctx
+                    .substitution
                     .get(&v)
                     .cloned()
                     .unwrap_or_else(|| Type::Variable(v));
@@ -509,7 +511,8 @@ impl<N: Name> Type<N> {
     ///
     /// [`TypeSchema`]: enum.TypeSchema.html
     pub fn generalize(&self, bound: &[Variable]) -> TypeSchema<N> {
-        let fvs = self.vars()
+        let fvs = self
+            .vars()
             .into_iter()
             .filter(|x| !bound.contains(x))
             .collect::<Vec<Variable>>();
@@ -658,7 +661,8 @@ impl<N: Name> From<VecDeque<Type<N>>> for Type<N> {
 }
 impl<N: Name> From<Vec<Type<N>>> for Type<N> {
     fn from(mut tps: Vec<Type<N>>) -> Type<N> {
-        let mut beta = tps.pop()
+        let mut beta = tps
+            .pop()
             .unwrap_or_else(|| panic!("cannot create a type from nothing"));
         while let Some(alpha) = tps.pop() {
             beta = Type::arrow(alpha, beta)


### PR DESCRIPTION
If you don't include the `∀`, all polytypes start with a monotype (e.g. t0), so putting monotypes first meant that `∀` wasn't actually optional. Switching the order of the alternatives resolves this bug. I also fixed a few formatting complaints from `cargo fmt`.