### PR TITLE
Rollback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ categories = ["science", "data-structures", "algorithms"]
 edition = "2018"
 
 [dependencies]
+indexmap = "1.0"
 itertools = "0.8"
 nom = "4.2"

--- a/src/context.rs
+++ b/src/context.rs
@@ -372,7 +372,7 @@ impl<N: Name> Context<N> {
 ///
 /// [`Context::merge`]: struct.Context.html#method.merge
 pub struct ContextChange {
-    delta: u16,
+    delta: usize,
     sacreds: Vec<Variable>,
 }
 impl ContextChange {

--- a/src/context.rs
+++ b/src/context.rs
@@ -87,6 +87,7 @@ impl<N: Name> Context<N> {
     pub fn clean(&mut self) {
         self.substitution = IndexMap::new();
     }
+    /// Removes the previous `n` substitutions added to the `Context`.
     pub fn rollback(&mut self, n: usize) {
         if n == 0 {
             self.clean()

--- a/src/context.rs
+++ b/src/context.rs
@@ -52,6 +52,33 @@ impl<N: Name> Context<N> {
     pub fn substitution(&self) -> &HashMap<Variable, Type<N>> {
         &self.substitution
     }
+    /// Clears the substitution managed by the context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{Type, Context, ptp, tp};
+    /// let mut ctx = Context::default();
+    ///
+    /// // Get a fresh variable
+    /// let t0 = ctx.new_variable();
+    /// let t1 = ctx.new_variable();
+    ///
+    /// let clean = ctx.clone();
+    ///
+    /// if let Type::Variable(N) = t0 {
+    ///     ctx.extend(N, tp![t1]);
+    ///     let dirty = ctx.clone();
+    ///
+    ///     ctx.clean();
+    ///
+    ///     assert_eq!(clean, ctx);
+    ///     assert_ne!(clean, dirty);
+    /// }
+    /// ```
+    pub fn clean(&mut self) {
+        self.substitution = HashMap::new();
+    }
     /// Create a new substitution for [`Type::Variable`] number `v` to the
     /// [`Type`] `t`.
     ///

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -22,7 +22,7 @@ pub fn parse_typeschema<N: Name>(input: &str) -> Result<TypeSchema<N>, ()> {
     }
 }
 
-fn nom_u16(inp: CompleteStr<'_>) -> Result<u16, ParseIntError> {
+fn nom_usize(inp: CompleteStr<'_>) -> Result<usize, ParseIntError> {
     inp.parse()
 }
 
@@ -37,7 +37,7 @@ impl<N: Name> Parser<N> {
     method!(
         var<Parser<N>, CompleteStr<'_>, Type<N>>,
         self,
-        do_parse!(tag!("t") >> num: map_res!(digit, nom_u16) >> (Type::Variable(num)))
+        do_parse!(tag!("t") >> num: map_res!(digit, nom_usize) >> (Type::Variable(num)))
     );
     method!(
         constructed_simple<Parser<N>, CompleteStr<'_>, Type<N>>,
@@ -78,7 +78,7 @@ impl<N: Name> Parser<N> {
                do_parse!(
                    opt!(tag!("∀")) >>
                    tag!("t") >>
-                   variable: map_res!(digit, nom_u16) >>
+                   variable: map_res!(digit, nom_usize) >>
                    ws!(tag!(".")) >>
                    body: map!(call_m!(self.polytype), Box::new) >>
                    (TypeSchema::Polytype{variable, body}))

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,7 +8,7 @@ use crate::{Context, Name};
 /// Represents a [type variable][1] (an unknown type).
 ///
 /// [1]: https://en.wikipedia.org/wiki/Hindley–Milner_type_system#Free_type_variables
-pub type Variable = u16;
+pub type Variable = usize;
 
 /// Represents [polytypes][1] (uninstantiated, universally quantified types).
 ///


### PR DESCRIPTION
Some updates to make it easier to manage the substitutions in a `Context`:
- add `pub fn clear()` to reinitialize a substitution
- add `pub fn rollback()` to remove the most recent substitutions
- change `Variable` to be a `usize` as it was pretty easy to overflow the `u16`.