### PR TITLE
Separate parser and nom dependency into feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,15 @@ keywords = ["typing", "language", "type", "inference", "unification"]
 categories = ["science", "data-structures", "algorithms"]
 edition = "2018"
 
+[features]
+default = ["parser"]
+parser = ["nom"]
+
 [dependencies]
 indexmap = "1.0"
 itertools = "0.8"
-nom = "=4.1.1"
+
+[dependencies.nom]
+version = "=4.1.1"
+optional = true
+

--- a/README.md
+++ b/README.md
@@ -67,3 +67,8 @@ assert_eq!(t2.to_string(), "list(t1)");
 ```
 
 See the [documentation](https://docs.rs/polytype) for more details.
+
+## Features
+By default `polytype` includes a type parser that can be invoked with `Type::parse`.
+This can be disabled with `default-features = false`.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@
 
 mod context;
 mod macros;
+#[cfg(feature = "parser")]
 mod parser;
 mod types;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -97,3 +97,60 @@ impl<N: Name> Parser<N> {
                  map!(call_m!(self.monotype), TypeSchema::Monotype))
         );
 }
+impl<N: Name> TypeSchema<N> {
+    /// Parse a [`TypeSchema`] from a string. This round-trips with [`Display`].
+    /// This is a **leaky** operation and should be avoided wherever possible:
+    /// names of constructed types will remain until program termination.
+    ///
+    /// The "for-all" `∀` is optional.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{ptp, tp, TypeSchema};
+    /// let t_par = TypeSchema::parse("∀t0. t0 -> t0").expect("valid type");
+    /// let t_lit = ptp!(0; @arrow[tp!(0), tp!(0)]);
+    /// assert_eq!(t_par, t_lit);
+    ///
+    /// let s = "∀t0. ∀t1. (t1 → t0 → t1) → t1 → list(t0) → t1";
+    /// let t: TypeSchema<&'static str> = TypeSchema::parse(s).expect("valid type");
+    /// let round_trip = t.to_string();
+    /// assert_eq!(s, round_trip);
+    /// ```
+    ///
+    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+    /// [`TypeSchema`]: enum.TypeSchema.html
+    pub fn parse(s: &str) -> Result<TypeSchema<N>, ()> {
+        parse_typeschema(s)
+    }
+}
+impl<N: Name> Type<N> {
+    /// Parse a type from a string. This round-trips with [`Display`]. This is a
+    /// **leaky** operation and should be avoided wherever possible: names of
+    /// constructed types will remain until program termination.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, Type};
+    /// let t_par = Type::parse("int -> hashmap(str, list(bool))").expect("valid type");
+    /// let t_lit = tp!(@arrow[
+    ///     tp!(int),
+    ///     tp!(hashmap(
+    ///         tp!(str),
+    ///         tp!(list(tp!(bool))),
+    ///     )),
+    /// ]);
+    /// assert_eq!(t_par, t_lit);
+    ///
+    /// let s = "(t1 → t0 → t1) → t1 → list(t0) → t1";
+    /// let t: Type<&'static str> = Type::parse(s).expect("valid type");
+    /// let round_trip = t.to_string();
+    /// assert_eq!(s, round_trip);
+    /// ```
+    ///
+    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+    pub fn parse(s: &str) -> Result<Type<N>, ()> {
+        parse_type(s)
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,6 @@ use itertools::Itertools;
 use std::collections::{HashMap, VecDeque};
 use std::fmt;
 
-use crate::parser::{parse_type, parse_typeschema};
 use crate::{Context, Name};
 
 /// Represents a [type variable][1] (an unknown type).
@@ -157,31 +156,6 @@ impl<N: Name> TypeSchema<N> {
                 body.instantiate_owned_internal(ctx, substitution)
             }
         }
-    }
-    /// Parse a [`TypeSchema`] from a string. This round-trips with [`Display`].
-    /// This is a **leaky** operation and should be avoided wherever possible:
-    /// names of constructed types will remain until program termination.
-    ///
-    /// The "for-all" `∀` is optional.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use polytype::{ptp, tp, TypeSchema};
-    /// let t_par = TypeSchema::parse("∀t0. t0 -> t0").expect("valid type");
-    /// let t_lit = ptp!(0; @arrow[tp!(0), tp!(0)]);
-    /// assert_eq!(t_par, t_lit);
-    ///
-    /// let s = "∀t0. ∀t1. (t1 → t0 → t1) → t1 → list(t0) → t1";
-    /// let t: TypeSchema<&'static str> = TypeSchema::parse(s).expect("valid type");
-    /// let round_trip = t.to_string();
-    /// assert_eq!(s, round_trip);
-    /// ```
-    ///
-    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
-    /// [`TypeSchema`]: enum.TypeSchema.html
-    pub fn parse(s: &str) -> Result<TypeSchema<N>, ()> {
-        parse_typeschema(s)
     }
 }
 impl<N: Name> fmt::Display for TypeSchema<N> {
@@ -569,34 +543,6 @@ impl<N: Name> Type<N> {
                 }
             }
         }
-    }
-    /// Parse a type from a string. This round-trips with [`Display`]. This is a
-    /// **leaky** operation and should be avoided wherever possible: names of
-    /// constructed types will remain until program termination.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use polytype::{tp, Type};
-    /// let t_par = Type::parse("int -> hashmap(str, list(bool))").expect("valid type");
-    /// let t_lit = tp!(@arrow[
-    ///     tp!(int),
-    ///     tp!(hashmap(
-    ///         tp!(str),
-    ///         tp!(list(tp!(bool))),
-    ///     )),
-    /// ]);
-    /// assert_eq!(t_par, t_lit);
-    ///
-    /// let s = "(t1 → t0 → t1) → t1 → list(t0) → t1";
-    /// let t: Type<&'static str> = Type::parse(s).expect("valid type");
-    /// let round_trip = t.to_string();
-    /// assert_eq!(s, round_trip);
-    /// ```
-    ///
-    /// [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
-    pub fn parse(s: &str) -> Result<Type<N>, ()> {
-        parse_type(s)
     }
 }
 impl<N: Name> fmt::Display for Type<N> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -330,6 +330,7 @@ fn test_merge_with_sacreds() {
     assert_eq!(ctx.new_variable(), tp!(7));
 }
 
+#[cfg(feature = "parser")]
 #[test]
 fn test_parse() {
     let t = tp!(int);


### PR DESCRIPTION
This pull request separates the parser component and `nom` dependency into a feature flag. This feature flag is enabled by default and is therefore a backwards compatible change.
## Rationale
I don't use the included parser in my compiler as I have a separate parser component for that (and I imagine that most people would as well). It was also surprising to me that the parser function was leaking. I think that `nom` can be considered an unnecessary dependency most of the time. 
