### PR TITLE
Minor edits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ edition = "2018"
 [dependencies]
 indexmap = "1.0"
 itertools = "0.8"
-nom = "4.2"
+nom = "=4.1.1"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,8 @@
 use nom::{alpha, digit, types::CompleteStr};
-use nom::{alt, call_m, do_parse, expr_res, map, map_res, method, opt, separated_list, tag, ws};
+use nom::{
+    alt, alt_sep, call_m, do_parse, error_position, expr_res, map, map_res, method, opt, sep,
+    separated_list, tag, wrap_sep, ws,
+};
 
 #[allow(unused_imports)]
 use nom::call; // FIXME see https://github.com/Geal/nom/pull/871

--- a/src/types.rs
+++ b/src/types.rs
@@ -430,7 +430,7 @@ impl<N: Name> Type<N> {
             Type::Variable(v) => ctx
                 .substitution
                 .get(&v)
-                .cloned()
+                .map(|tp| tp.apply(ctx))
                 .unwrap_or_else(|| Type::Variable(v)),
         }
     }
@@ -448,7 +448,7 @@ impl<N: Name> Type<N> {
                 *self = ctx
                     .substitution
                     .get(&v)
-                    .cloned()
+                    .map(|tp| tp.apply(ctx))
                     .unwrap_or_else(|| Type::Variable(v));
             }
         }


### PR DESCRIPTION
A couple small tweaks:
- revert and fix the `nom` version to `=4.1.1` to avoid warnings related to `nom_methods`.
- recursively apply `Type::apply` to ensure the result includes all possible substitutions.