### PR TITLE
context.rs: Correct the docstring for rollback().

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -87,7 +87,7 @@ impl<N: Name> Context<N> {
     pub fn clean(&mut self) {
         self.substitution = IndexMap::new();
     }
-    /// Removes the previous `n` substitutions added to the `Context`.
+    /// Removes previous substitutions added to the `Context` until there are only `n` remaining.
     pub fn rollback(&mut self, n: usize) {
         if n == 0 {
             self.clean()


### PR DESCRIPTION
`rollback()` gets called with the previous length of `substitution`, not the number of substitutions added.