### PR TITLE
Interning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ default = ["parser"]
 parser = ["nom"]
 
 [dependencies]
+fnv = "1.0"
 indexmap = "1.0"
 itertools = "0.8"
+smallvec = "1.4"
+typed-arena = "2.0"
 
 [dependencies.nom]
 version = "=4.1.1"

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,439 +1,412 @@
-use crate::{Name, Type, TypeSchema, Variable};
-use indexmap::IndexMap;
-use std::{cell::RefCell, collections::HashMap, error, fmt};
+use crate::{Name, Schema, Ty, Type, TypeSchema, Variable};
+use fnv::FnvHashMap;
+use itertools::Itertools;
+use std::{
+    borrow::Borrow,
+    cell::RefCell,
+    hash::{Hash, Hasher},
+};
+use typed_arena::Arena;
 
-/// Errors during unification.
-#[derive(Debug, Clone, PartialEq)]
-pub enum UnificationError<N: Name = &'static str> {
-    /// `Occurs` happens when occurs checks fail (i.e. a type variable is
-    /// unified recursively). The id of the bad type variable is supplied.
-    Occurs(Variable),
-    /// `Failure` happens when symbols or type variants don't unify because of
-    /// structural differences.
-    Failure(Type<N>, Type<N>),
-}
-impl<N: Name> fmt::Display for UnificationError<N> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match *self {
-            UnificationError::Occurs(v) => write!(f, "Occurs({})", v),
-            UnificationError::Failure(ref t1, ref t2) => {
-                write!(f, "Failure({}, {})", t1.show(false), t2.show(false))
-            }
-        }
-    }
-}
-impl<N: Name + fmt::Debug> error::Error for UnificationError<N> {
-    fn description(&self) -> &'static str {
-        "unification failed"
-    }
-}
+struct Interner<'a, K>(RefCell<FnvHashMap<&'a K, ()>>);
 
-/// A type environment. Useful for reasoning about [`Type`]s (e.g unification,
-/// type inference).
-///
-/// Contexts track substitutions and generate fresh type variables.
-///
-/// [`Type`]: enum.Type.html
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Context<N: Name = &'static str> {
-    /// A set of constraints mapping from [`Variable`]s to [`Type`]s.
-    ///
-    /// [`Type`]: enum.Type.html
-    /// [`Variable`]: type.Variable.html
-    pub(crate) substitution: IndexMap<Variable, Type<N>>,
-    /// Some operations on [`Type`]s, notably [`apply`] and [`apply_mut`]
-    /// perform path compression as they operate. Path compression is a
-    /// technique commonly used in [Union-Find data structures]. We apply it
-    /// here so that whenever a chain of substitutions is traversed, each
-    /// variable is updated to point to its ultimate value. For example, the
-    /// chain:
-    ///
-    /// `t0 ↦ t1`, `t1 ↦ t2`, and `t2 ↦ int`
-    ///
-    /// becomes
-    ///
-    /// `t0 ↦ int`, `t1 ↦ int`, and `t2 ↦ int`
-    ///
-    /// Rather than updating the actual mappings, `Context` maintains this cache
-    /// of compressed mappings.
-    ///
-    /// [Union-Find data structure]: https://en.wikipedia.org/wiki/Disjoint-set_data_structure
-    /// [`Type`]: enum.Type.html
-    /// [`apply`]: enum.Type.html#method.apply
-    /// [`apply_mut`]: enum.Type.html#method.apply_mut
-    pub(crate) path_compression_cache: RefCell<HashMap<Variable, Type<N>>>,
-    /// A counter used to generate fresh [`Variable`]s
-    ///
-    /// [`Variable`]: type.Variable.html
-    next: Variable,
-}
-impl<N: Name> Default for Context<N> {
-    fn default() -> Self {
-        Context {
-            substitution: IndexMap::new(),
-            path_compression_cache: RefCell::new(HashMap::new()),
-            next: 0,
-        }
+struct SliceInterner<'a, K>(RefCell<FnvHashMap<&'a [K], ()>>);
+
+impl<'a, K: Eq + Hash> Interner<'a, K> {
+    fn with_capacity(n: usize) -> Self {
+        Interner(RefCell::new(FnvHashMap::with_capacity_and_hasher(
+            n,
+            Default::default(),
+        )))
     }
-}
-impl<N: Name> Context<N> {
-    /// The substitution managed by the context.
-    pub fn substitution(&self) -> &IndexMap<Variable, Type<N>> {
-        &self.substitution
-    }
-    /// The number of constraints in the substitution.
-    pub fn len(&self) -> usize {
-        self.substitution.len()
-    }
-    /// `true` if the substitution has any constraints, else `false`.
-    pub fn is_empty(&self) -> bool {
-        self.substitution.is_empty()
-    }
-    /// Clears the substitution managed by the context.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use polytype::{Type, Context, ptp, tp};
-    /// let mut ctx = Context::default();
-    ///
-    /// // Get a fresh variable
-    /// let t0 = ctx.new_variable();
-    /// let t1 = ctx.new_variable();
-    ///
-    /// let clean = ctx.clone();
-    ///
-    /// if let Type::Variable(N) = t0 {
-    ///     ctx.extend(N, tp![t1]);
-    ///     let dirty = ctx.clone();
-    ///
-    ///     ctx.clean();
-    ///
-    ///     assert_eq!(clean, ctx);
-    ///     assert_ne!(clean, dirty);
-    /// }
-    /// ```
-    pub fn clean(&mut self) {
-        self.substitution.clear();
-        self.path_compression_cache.get_mut().clear();
-    }
-    /// Removes previous substitutions added to the `Context` until there are only `n` remaining.
-    pub fn rollback(&mut self, n: usize) {
-        self.path_compression_cache.get_mut().clear();
-        if n == 0 {
-            self.substitution.clear();
+    pub fn intern<Q>(&self, value: K, make: impl FnOnce(K) -> &'a K) -> &'a K
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        let mut table = self.0.borrow_mut();
+        // TODO: might not be super-efficient
+        if let Some((k, _)) = table.get_key_value(&value) {
+            &k
         } else {
-            while n < self.substitution.len() {
-                self.substitution.pop();
-            }
+            let k = make(value);
+            table.insert(k, ());
+            k
         }
-    }
-    /// Create a new substitution for [`Type::Variable`] number `v` to the
-    /// [`Type`] `t`.
-    ///
-    /// [`Type`]: enum.Type.html
-    /// [`Type::Variable`]: enum.Type.html#variant.Variable
-    pub fn extend(&mut self, v: Variable, t: Type<N>) {
-        if v >= self.next {
-            self.next = v + 1
-        }
-        self.substitution.insert(v, t);
-    }
-    /// Create a new [`Type::Variable`] from the next unused number.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use polytype::{Type, Context, ptp, tp};
-    /// let mut ctx = Context::default();
-    ///
-    /// // Get a fresh variable
-    /// let t0 = ctx.new_variable();
-    /// assert_eq!(t0, Type::Variable(0));
-    ///
-    /// // Instantiating a polytype will yield new variables
-    /// let t = ptp!(0, 1; @arrow[tp!(0), tp!(1), tp!(1)]);
-    /// let t = t.instantiate(&mut ctx);
-    /// assert_eq!(t.to_string(), "t1 → t2 → t2");
-    ///
-    /// // Get another fresh variable
-    /// let t3 = ctx.new_variable();
-    /// assert_eq!(t3, Type::Variable(3));
-    /// ```
-    ///
-    /// [`Type::Variable`]: enum.Type.html#variant.Variable
-    pub fn new_variable(&mut self) -> Type<N> {
-        self.next += 1;
-        Type::Variable(self.next - 1)
-    }
-    /// Create constraints within the context that ensure `t1` and `t2`
-    /// unify.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use polytype::{Context, tp};
-    /// let mut ctx = Context::default();
-    ///
-    /// let t1 = tp!(@arrow[tp!(int), tp!(0)]);
-    /// let t2 = tp!(@arrow[tp!(1), tp!(bool)]);
-    /// ctx.unify(&t1, &t2).expect("unifies");
-    ///
-    /// let t1 = t1.apply(&ctx);
-    /// let t2 = t2.apply(&ctx);
-    /// assert_eq!(t1, t2);  // int → bool
-    /// ```
-    ///
-    /// Unification errors leave the context unaffected. A
-    /// [`UnificationError::Failure`] error happens when symbols don't match:
-    ///
-    /// ```
-    /// # use polytype::{Context, UnificationError, tp};
-    /// let mut ctx = Context::default();
-    ///
-    /// let t1 = tp!(@arrow[tp!(int), tp!(0)]);
-    /// let t2 = tp!(@arrow[tp!(bool), tp!(1)]);
-    /// let res = ctx.unify(&t1, &t2);
-    ///
-    /// if let Err(UnificationError::Failure(left, right)) = res {
-    ///     // failed to unify t1 with t2.
-    ///     assert_eq!(left, tp!(int));
-    ///     assert_eq!(right, tp!(bool));
-    /// } else { unreachable!() }
-    /// ```
-    ///
-    /// An [`UnificationError::Occurs`] error happens when the same type
-    /// variable occurs in both types in a circular way. Ensure you
-    /// [`instantiate`][] your types properly, so type variables don't overlap
-    /// unless you mean them to.
-    ///
-    /// ```
-    /// # use polytype::{Context, UnificationError, tp};
-    /// let mut ctx = Context::default();
-    ///
-    /// let t1 = tp!(1);
-    /// let t2 = tp!(@arrow[tp!(bool), tp!(1)]);
-    /// let res = ctx.unify(&t1, &t2);
-    ///
-    /// if let Err(UnificationError::Occurs(v)) = res {
-    ///     // failed to unify t1 with t2 because of circular type variable occurrence.
-    ///     // t1 would have to be bool -> bool -> ... ad infinitum.
-    ///     assert_eq!(v, 1);
-    /// } else { unreachable!() }
-    /// ```
-    ///
-    /// [`UnificationError::Failure`]: enum.UnificationError.html#variant.Failure
-    /// [`UnificationError::Occurs`]: enum.UnificationError.html#variant.Occurs
-    /// [`instantiate`]: enum.Type.html#method.instantiate
-    pub fn unify(&mut self, t1: &Type<N>, t2: &Type<N>) -> Result<(), UnificationError<N>> {
-        let rollback_n = self.substitution.len();
-        let t1 = t1.apply(self);
-        let t2 = t2.apply(self);
-        let result = self.unify_internal(t1, t2);
-        if result.is_err() {
-            self.rollback(rollback_n);
-        }
-        result
-    }
-    /// Like [`unify`], but may affect the context even under failure. Hence, use this if you
-    /// discard the context upon failure.
-    ///
-    /// [`unify`]: #method.unify
-    pub fn unify_fast(
-        &mut self,
-        mut t1: Type<N>,
-        mut t2: Type<N>,
-    ) -> Result<(), UnificationError<N>> {
-        t1.apply_mut(self);
-        t2.apply_mut(self);
-        self.unify_internal(t1, t2)
-    }
-    /// unify_internal may mutate the context even with an error. The context on
-    /// which it's called should be discarded if there's an error.
-    fn unify_internal(&mut self, t1: Type<N>, t2: Type<N>) -> Result<(), UnificationError<N>> {
-        if t1 == t2 {
-            return Ok(());
-        }
-        match (t1, t2) {
-            (Type::Variable(v), t2) => {
-                if t2.occurs(v) {
-                    Err(UnificationError::Occurs(v))
-                } else {
-                    self.extend(v, t2);
-                    Ok(())
-                }
-            }
-            (t1, Type::Variable(v)) => {
-                if t1.occurs(v) {
-                    Err(UnificationError::Occurs(v))
-                } else {
-                    self.extend(v, t1);
-                    Ok(())
-                }
-            }
-            (Type::Constructed(n1, a1), Type::Constructed(n2, a2)) => {
-                if n1 != n2 {
-                    Err(UnificationError::Failure(
-                        Type::Constructed(n1, a1),
-                        Type::Constructed(n2, a2),
-                    ))
-                } else {
-                    for (mut t1, mut t2) in a1.into_iter().zip(a2) {
-                        t1.apply_mut(self);
-                        t2.apply_mut(self);
-                        self.unify_internal(t1, t2)?;
-                    }
-                    Ok(())
-                }
-            }
-        }
-    }
-    /// Confines the substitution to those which act on the given variables.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use polytype::{Context, tp};
-    /// let mut ctx = Context::default();
-    /// let v0 = ctx.new_variable();
-    /// let v1 = ctx.new_variable();
-    /// ctx.unify(&v0, &tp!(int));
-    /// ctx.unify(&v1, &tp!(bool));
-    ///
-    /// {
-    ///     let sub = ctx.substitution();
-    ///     assert_eq!(sub.len(), 2);
-    ///     assert_eq!(sub[&0], tp!(int));
-    ///     assert_eq!(sub[&1], tp!(bool));
-    /// }
-    ///
-    /// // confine the substitution to v1
-    /// ctx.confine(&[1]);
-    /// let sub = ctx.substitution();
-    /// assert_eq!(sub.len(), 1);
-    /// assert_eq!(sub[&1], tp!(bool));
-    /// ```
-    pub fn confine(&mut self, keep: &[Variable]) {
-        let mut substitution = IndexMap::new();
-        for v in keep {
-            substitution.insert(*v, self.substitution[v].clone());
-        }
-        self.substitution = substitution;
-    }
-    /// Merge two type contexts.
-    ///
-    /// Every [`Type`] ([`TypeSchema`]) that corresponds to the `other` context
-    /// must be reified using [`ContextChange::reify_type`]
-    /// ([`ContextChange::reify_typeschema`]). Any [`Variable`] in `sacreds`
-    /// will not be changed by the context (i.e. reification will ignore it).
-    ///
-    /// # Examples
-    ///
-    /// Without sacred variables, which assumes that all type variables between the contexts are
-    /// distinct:
-    ///
-    /// ```
-    /// # use polytype::{Type, Context, ptp, tp};
-    /// let mut ctx = Context::default();
-    /// let a = ctx.new_variable();
-    /// let b = ctx.new_variable();
-    /// ctx.unify(&Type::arrow(a, b), &tp!(@arrow[tp!(int), tp!(bool)])).unwrap();
-    /// // ctx uses t0 and t1
-    ///
-    /// let mut ctx2 = Context::default();
-    /// let pt = ptp!(0, 1; @arrow[tp!(0), tp!(1)]);
-    /// let mut t = pt.instantiate(&mut ctx2);
-    /// ctx2.extend(0, tp!(bool));
-    /// assert_eq!(t.apply(&ctx2).to_string(), "bool → t1");
-    /// // ctx2 uses t0 and t1
-    ///
-    /// let ctx_change = ctx.merge(ctx2, vec![]);
-    /// // rewrite all terms under ctx2 using ctx_change
-    /// ctx_change.reify_type(&mut t);
-    /// assert_eq!(t.to_string(), "t2 → t3");
-    /// assert_eq!(t.apply(&ctx).to_string(), "bool → t3");
-    ///
-    /// assert_eq!(ctx.new_variable(), tp!(4));
-    /// ```
-    ///
-    /// With sacred variables, which specifies which type variables are equivalent in both
-    /// contexts:
-    ///
-    /// ```
-    /// # use polytype::{Type, Context, tp};
-    /// let mut ctx = Context::default();
-    /// let a = ctx.new_variable();
-    /// let b = ctx.new_variable();
-    /// ctx.unify(&Type::arrow(a, b), &tp!(@arrow[tp!(int), tp!(bool)])).unwrap();
-    /// // ctx uses t0 and t1
-    ///
-    /// let mut ctx2 = Context::default();
-    /// let a = ctx2.new_variable();
-    /// let b = ctx2.new_variable();
-    /// let mut t = Type::arrow(a, b);
-    /// ctx2.extend(0, tp!(bool));
-    /// assert_eq!(t.apply(&ctx2).to_string(), "bool → t1");
-    /// // ctx2 uses t0 and t1
-    ///
-    /// // t1 from ctx2 is preserved *and* constrained by ctx
-    /// let ctx_change = ctx.merge(ctx2, vec![1]);
-    /// // rewrite all terms under ctx2 using ctx_change
-    /// ctx_change.reify_type(&mut t);
-    /// assert_eq!(t.to_string(), "t2 → t1");
-    /// assert_eq!(t.apply(&ctx).to_string(), "bool → bool");
-    ///
-    /// assert_eq!(ctx.new_variable(), tp!(4));
-    /// ```
-    /// [`ContextChange::reify_type`]: struct.ContextChange.html#method.reify_type
-    /// [`ContextChange::reify_typeschema`]: struct.ContextChange.html#method.reify_typeschema
-    /// [`Type`]: enum.Type.html
-    /// [`TypeSchema`]: enum.TypeSchema.html
-    /// [`Variable`]: type.TypeSchema.html
-    pub fn merge(&mut self, other: Context<N>, sacreds: Vec<Variable>) -> ContextChange {
-        let delta = self.next;
-        for (v, tp) in other.substitution {
-            self.substitution.insert(delta + v, tp);
-        }
-        // this is intentionally wasting variable space when there are sacreds:
-        self.next += other.next;
-        ContextChange { delta, sacreds }
     }
 }
 
-/// Allow types to be reified for use in a different context. See [`Context::merge`].
-///
-/// [`Context::merge`]: struct.Context.html#method.merge
-pub struct ContextChange {
-    delta: usize,
-    sacreds: Vec<Variable>,
+impl<'a, K> Default for Interner<'a, K> {
+    fn default() -> Self {
+        Interner(RefCell::new(FnvHashMap::default()))
+    }
 }
-impl ContextChange {
-    /// Reify a [`Type`] for use under a merged [`Context`].
-    ///
-    /// [`Type`]: enum.Type.html
-    /// [`Context`]: struct.Context.html
-    pub fn reify_type(&self, tp: &mut Type) {
-        match tp {
-            Type::Constructed(_, args) => {
-                for arg in args {
-                    self.reify_type(arg)
-                }
-            }
-            Type::Variable(n) if self.sacreds.contains(n) => (),
-            Type::Variable(n) => *n += self.delta,
+
+impl<'a, K: Eq + Hash> SliceInterner<'a, K> {
+    pub fn with_capacity(n: usize) -> Self {
+        SliceInterner(RefCell::new(FnvHashMap::with_capacity_and_hasher(
+            n,
+            Default::default(),
+        )))
+    }
+    pub fn intern(&self, value: &[K], make: impl FnOnce(&[K]) -> &'a [K]) -> &'a [K] {
+        let mut table = self.0.borrow_mut();
+        // TODO: might not be super-efficient
+        let opt: Option<(&&'a [K], _)> = table.get_key_value(value);
+        if let Some((k, _)) = opt {
+            *k
+        } else {
+            let k = make(value);
+            table.insert(k, ());
+            k
         }
     }
-    /// Reify a [`TypeSchema`] for use under a merged [`Context`].
+}
+
+impl<'a, K> Default for SliceInterner<'a, K> {
+    fn default() -> Self {
+        SliceInterner(RefCell::new(FnvHashMap::default()))
+    }
+}
+
+#[derive(Copy)]
+/// The universe within which a [`Variable`], [`Type`], or [`TypeSchema`]
+/// exists.
+///
+/// A `TypeContext` interns these values for more efficient reasoning. That is,
+/// it stores owned copies of [`Type`]s and [`TypeSchema`]s. Whenever
+/// requested, it returns a reference to these values in the form of a [`Ty`] or
+/// [`Schema`]. These reference types are the primary way end-users interact
+/// with types.
+///
+/// [`Variable`]: struct.Variable.html
+/// [`Type`]: enum.Type.html
+/// [`TypeSchema`]: enum.TypeSchema.html
+/// [`Ty`]: type.Ty.html
+/// [`Schema`]: type.Schema.html
+pub struct TypeContext<'ctx, N: Name = &'static str> {
+    ctx: &'ctx Context<'ctx, N>,
+}
+
+impl<'ctx, N: Name> PartialEq for TypeContext<'ctx, N> {
+    fn eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.ctx, other.ctx)
+    }
+}
+
+impl<'ctx, N: Name> std::fmt::Debug for TypeContext<'ctx, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "TypeContext<'ctx, N> {{ ctx: {:p} }}", self.ctx)
+    }
+}
+
+impl<'ctx, N: Name> Eq for TypeContext<'ctx, N> {}
+
+impl<'ctx, N: Name> Clone for TypeContext<'ctx, N> {
+    fn clone(&self) -> Self {
+        TypeContext { ctx: self.ctx }
+    }
+}
+
+impl<'ctx, N: Name> Hash for TypeContext<'ctx, N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (self.ctx as *const Context<'ctx, N>).hash(state)
+    }
+}
+
+/// The inner type managed by a [`TypeContext`]. A `Context` is not manipulated directly.
+///
+/// [`TypeContext`]: struct.TypeContext.html
+pub struct Context<'ctx, N: Name = &'static str> {
+    schema_arena: &'ctx Arena<TypeSchema<'ctx, N>>,
+    schema_map: Interner<'ctx, TypeSchema<'ctx, N>>,
+    type_arena: &'ctx Arena<Type<'ctx, N>>,
+    type_map: Interner<'ctx, Type<'ctx, N>>,
+    name_arena: &'ctx Arena<N>,
+    name_map: Interner<'ctx, N>,
+    arg_arena: &'ctx Arena<Ty<'ctx, N>>,
+    arg_map: SliceInterner<'ctx, Ty<'ctx, N>>,
+}
+
+/// This is the most straightforward way to gain access to a [`TypeContext`].
+///
+/// `with_ctx` creates a [`TypeContext`], `ctx`, with `n` slots pre-allocated in
+/// each arena, calls `f(ctx)`, and returns the result.
+///
+/// # Examples
+///
+/// ```
+/// # use polytype::{ptp, tp, with_ctx, Context, Source, Substitution, Variable};
+/// let t_string = with_ctx(32, |ctx| {
+///   // filter: ∀α. (α → bool) → [α] → [α]
+///   let t = ptp!(ctx, 0; @arrow[
+///       tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx, bool)]),
+///       tp!(ctx, list(tp!(ctx, 0))),
+///       tp!(ctx, list(tp!(ctx, 0))),
+///   ]);
+///   t.to_string()
+/// });
+/// assert_eq!(t_string, "∀t0. (t0 → bool) → list(t0) → list(t0)");
+/// ```
+///
+/// [`TypeContext`]: struct.TypeContext.html
+pub fn with_ctx<F, R, M: Name>(n: usize, f: F) -> R
+where
+    F: FnOnce(TypeContext<'_, M>) -> R,
+{
+    let schemaa: Arena<TypeSchema<'_, M>> = Arena::with_capacity(n);
+    let typea: Arena<Type<'_, M>> = Arena::with_capacity(n);
+    let namea: Arena<M> = Arena::with_capacity(n);
+    let tya: Arena<Ty<'_, M>> = Arena::with_capacity(n);
+    let ctx = Context::with_capacity(&schemaa, &typea, &namea, &tya, n);
+    let ctx: TypeContext<'_, M> = TypeContext::new(&ctx);
+    f(ctx)
+}
+
+impl<'ctx, N: Name> TypeContext<'ctx, N> {
+    /// Create a new `TypeContext` from a [`Context`].
     ///
-    /// [`TypeSchema`]: enum.TypeSchema.html
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_arena::Arena;
+    /// # use polytype::{ptp, tp, Context, TypeContext, Type, TypeSchema, Ty};
+    /// let schemaa: Arena<TypeSchema<'_>> = Arena::with_capacity(10);
+    /// let typea: Arena<Type<'_>> = Arena::with_capacity(10);
+    /// let namea: Arena<&'static str> = Arena::with_capacity(10);
+    /// let tya: Arena<Ty<'_>> = Arena::with_capacity(10);
+    /// let context = Context::with_capacity(&schemaa, &typea, &namea, &tya, 10);
+    /// let ctx = TypeContext::new(&context);
+    /// let t = ptp!(ctx, 0; @arrow[
+    ///     tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx, 1)]),
+    ///     tp!(ctx, list(tp!(ctx, 0))),
+    ///     tp!(ctx, list(tp!(ctx, 1))),
+    /// ]);
+    /// assert_eq!(t.to_string(), "∀t0. (t0 → t1) → list(t0) → list(t1)");
+    /// ```
+    ///
     /// [`Context`]: struct.Context.html
-    pub fn reify_typeschema(&self, tpsc: &mut TypeSchema) {
-        match tpsc {
-            TypeSchema::Monotype(tp) => self.reify_type(tp),
-            TypeSchema::Polytype { variable, body } => {
-                *variable += self.delta;
-                self.reify_typeschema(body);
-            }
+    pub fn new(ctx: &'ctx Context<'ctx, N>) -> Self {
+        TypeContext { ctx }
+    }
+    /// Intern a variable [`Type`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx: TypeContext<'_>| {
+    ///   let t = ctx.intern_tvar(Variable(0));
+    ///   assert_eq!(t.to_string(), "t0");
+    /// });
+    /// ```
+    ///
+    /// [`Type`]: enum.Type.html
+    pub fn intern_tvar(&self, v: Variable) -> Ty<'ctx, N> {
+        let t = Type::Variable(v);
+        self.ctx
+            .type_map
+            .intern(t, |t| self.ctx.type_arena.alloc(t))
+    }
+    /// Intern a `&[`[`Ty`]`]`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// # use polytype::{with_ctx, Variable};
+    /// # use itertools::Itertools;
+    /// with_ctx(32, |ctx| {
+    ///   let ts = ctx.intern_args(&[tp!(ctx, int), tp!(ctx, bool)]);
+    ///   assert_eq!(format!("[{}]", ts.iter().format!(", ")), "[int, bool]");
+    /// });
+    /// ```
+    ///
+    /// [`Ty`]: type.Ty.html
+    pub(crate) fn intern_args(&self, args: &[Ty<'ctx, N>]) -> &'ctx [Ty<'ctx, N>] {
+        self.ctx.arg_map.intern(args, |args| {
+            self.ctx.arg_arena.alloc_extend(args.iter().copied())
+        })
+    }
+    /// Intern a non-variable [`Type`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let name = ctx.intern_name("dict");
+    ///   let t = ctx.intern_tcon(name, &[tp!(ctx, int), tp!(ctx, bool)]);
+    ///   assert_eq!(t.to_string(), "dict(int,bool)");
+    /// });
+    /// ```
+    ///
+    /// [`Type`]: enum.Type.html
+    pub fn intern_tcon(&self, head: &'ctx N, args: &[Ty<'ctx, N>]) -> Ty<'ctx, N> {
+        let body = self.intern_args(args);
+        let t = Type::Constructed(head, body);
+        self.ctx
+            .type_map
+            .intern(t, |t| self.ctx.type_arena.alloc(t))
+    }
+    /// Intern a function (i.e. arrow) [`Type`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let t = ctx.arrow(tp!(ctx, 0), tp!(ctx, bool));
+    ///   assert_eq!(t.to_string(), "t0 → bool");
+    /// });
+    /// ```
+    ///
+    /// [`Type`]: enum.Type.html
+    pub fn arrow(&self, alpha: Ty<'ctx, N>, beta: Ty<'ctx, N>) -> Ty<'ctx, N> {
+        let head = self.intern_name(N::arrow());
+        self.intern_tcon(head, &[alpha, beta])
+    }
+    /// Intern a nested sequence of left-associative functions (i.e. arrow) as a
+    /// single [`Type`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let t = ctx.arrow_slice(&[tp!(ctx, 0), tp!(ctx, int), tp!(ctx, bool)]);
+    ///   assert_eq!(t.to_string(), "t0 → int → bool");
+    /// });
+    /// ```
+    ///
+    /// [`Type`]: enum.Type.html
+    pub fn arrow_slice(&self, tps: &[Ty<'ctx, N>]) -> Ty<'ctx, N> {
+        tps.iter()
+            .rev()
+            .copied()
+            .fold1(|x, y| self.arrow(y, x))
+            .unwrap_or_else(|| panic!("cannot create a type from nothing"))
+    }
+    /// Intern a [`Ty`] as a [`TypeSchema::Monotype`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let t = tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx,int), tp!(ctx, bool)]);
+    ///   let schema = ctx.intern_monotype(t);
+    ///   assert_eq!(schema.to_string(), "t0 → int → bool");
+    /// });
+    /// ```
+    ///
+    /// [`Ty`]: type.Ty.html
+    /// [`TypeSchema::Monotype`]: enum.TypeSchema.html#variant.Monotype
+    pub fn intern_monotype(&self, inner: Ty<'ctx, N>) -> Schema<'ctx, N> {
+        let t = TypeSchema::Monotype(inner);
+        self.ctx
+            .schema_map
+            .intern(t, |t| self.ctx.schema_arena.alloc(t))
+    }
+    /// Intern a [`Ty`] as a [`TypeSchema::Polytype`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let t = tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx,int), tp!(ctx, bool)]);
+    ///   let mono = ctx.intern_monotype(t);
+    ///   let poly = ctx.intern_polytype(Variable(0), mono);
+    ///   assert_eq!(poly.to_string(), "∀t0. t0 → int → bool");
+    /// });
+    /// ```
+    ///
+    /// [`Ty`]: type.Ty.html
+    /// [`TypeSchema::Polytype`]: enum.TypeSchema.html#variant.Polytype
+    pub fn intern_polytype(&self, v: Variable, body: Schema<'ctx, N>) -> Schema<'ctx, N> {
+        let t = TypeSchema::Polytype(v, body);
+        self.ctx
+            .schema_map
+            .intern(t, |t| self.ctx.schema_arena.alloc(t))
+    }
+    /// Intern a type constructor name.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let bool_name = ctx.intern_name("bool");
+    ///   assert_eq!(*bool_name, "bool");
+    /// });
+    /// ```
+    pub fn intern_name(&self, n: N) -> &'ctx N {
+        self.ctx
+            .name_map
+            .intern(n, |n| self.ctx.name_arena.alloc(n))
+    }
+}
+
+impl<'ctx, N: Name> Context<'ctx, N> {
+    /// Create a `Context`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_arena::Arena;
+    /// # use polytype::{ptp, tp, Context, TypeContext, Type, TypeSchema, Ty};
+    /// let schemaa: Arena<TypeSchema<'_>> = Arena::with_capacity(10);
+    /// let typea: Arena<Type<'_>> = Arena::with_capacity(10);
+    /// let namea: Arena<&'static str> = Arena::with_capacity(10);
+    /// let tya: Arena<Ty<'_>> = Arena::with_capacity(10);
+    /// let context = Context::new(&schemaa, &typea, &namea, &tya);
+    /// ```
+    pub fn new(
+        schema_arena: &'ctx Arena<TypeSchema<'ctx, N>>,
+        type_arena: &'ctx Arena<Type<'ctx, N>>,
+        name_arena: &'ctx Arena<N>,
+        arg_arena: &'ctx Arena<Ty<'ctx, N>>,
+    ) -> Self {
+        Context {
+            schema_arena,
+            schema_map: Interner::default(),
+            type_arena,
+            type_map: Interner::default(),
+            name_arena,
+            name_map: Interner::default(),
+            arg_arena,
+            arg_map: SliceInterner::default(),
+        }
+    }
+    /// Create a `Context` and reserve capacity for type interning.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use typed_arena::Arena;
+    /// # use polytype::{ptp, tp, Context, TypeContext, Type, TypeSchema, Ty};
+    /// let schemaa: Arena<TypeSchema<'_>> = Arena::with_capacity(10);
+    /// let typea: Arena<Type<'_>> = Arena::with_capacity(10);
+    /// let namea: Arena<&'static str> = Arena::with_capacity(10);
+    /// let tya: Arena<Ty<'_>> = Arena::with_capacity(10);
+    /// let context = Context::with_capacity(&schemaa, &typea, &namea, &tya, 10);
+    /// ```
+    pub fn with_capacity(
+        schema_arena: &'ctx Arena<TypeSchema<'ctx, N>>,
+        type_arena: &'ctx Arena<Type<'ctx, N>>,
+        name_arena: &'ctx Arena<N>,
+        arg_arena: &'ctx Arena<Ty<'ctx, N>>,
+        n: usize,
+    ) -> Self {
+        Context {
+            schema_arena,
+            schema_map: Interner::with_capacity(n),
+            type_arena,
+            type_map: Interner::with_capacity(n),
+            name_arena,
+            name_map: Interner::with_capacity(n),
+            arg_arena,
+            arg_map: SliceInterner::with_capacity(n),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,113 +1,132 @@
 //! A [Hindley-Milner polymorphic typing system].
 //!
-//! For brevity, the documentation heavily uses the two provided macros when
-//! creating types.
-//!
 //! A [`TypeSchema`] is a type that may have universally quantified type
-//! variables. A [`Context`] keeps track of assignments made to type variables
-//! so that you may manipulate [`Type`]s, which are unquantified and concrete.
-//! Hence a `TypeSchema` can be instantiated, using [`TypeSchema::instantiate`],
-//! into a `Context` in order to produce a corresponding `Type`. Two `Type`s
-//! under a particular `Context` can be unified using [`Context::unify`], which
-//! may record new type variable assignments in the `Context`.
+//! variables. You can use [`TypeSchema::instantiate`] to produce a
+//! corresponding [`Type`], which is unquantified. Both can contain
+//! [`Variable`]s, which are concrete but unknown types. [`Type::unify`] unifies
+//! two [`Type`]s, recording constraints on [`Variable`]s in a [`Substitution`].
+//! The [`Infer`] trait provides a simple interface for using these abilities to
+//! support custom type inference and type checking algorithms. All types are
+//! managed within a given [`TypeContext`], which interns type information for
+//! faster inference. As a result, most user-facing access comes by way of
+//! [`Schema`] and [`Ty`], references to interned [`TypeSchema`]s and [`Type`]s,
+//! respectively.
+//!
+//! For brevity, the documentation heavily uses the two provided macros [`tp`]
+//! and [`ptp`] when creating types.
 //!
 //! # Examples
 //!
 //! The basics:
 //!
 //! ```
-//! use polytype::{ptp, tp, Context};
+//! use polytype::{ptp, tp, with_ctx, Context, Source, Substitution, Variable};
 //!
-//! // filter: ∀α. (α → bool) → [α] → [α]
-//! let t = ptp!(0; @arrow[
-//!     tp!(@arrow[tp!(0), tp!(bool)]),
-//!     tp!(list(tp!(0))),
-//!     tp!(list(tp!(0))),
-//! ]);
+//! // Types are defined with respect to a given TypeContext. Here, it's `ctx`.
+//! with_ctx(32, |ctx| {
+//!   // filter: ∀α. (α → bool) → [α] → [α]
+//!   let t = ptp!(ctx, 0; @arrow[
+//!       tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx, bool)]),
+//!       tp!(ctx, list(tp!(ctx, 0))),
+//!       tp!(ctx, list(tp!(ctx, 0))),
+//!   ]);
 //!
-//! // Quantified type schemas provide polymorphic behavior.
-//! assert_eq!(t.to_string(), "∀t0. (t0 → bool) → list(t0) → list(t0)");
+//!   // Quantified type schemas provide polymorphic behavior.
+//!   assert_eq!(t.to_string(), "∀t0. (t0 → bool) → list(t0) → list(t0)");
 //!
-//! // We can instantiate type schemas to remove quantifiers
-//! let mut ctx = Context::default();
-//! let t = t.instantiate(&mut ctx);
-//! assert_eq!(t.to_string(), "(t0 → bool) → list(t0) → list(t0)");
+//!   // We can instantiate type schemas to remove quantifiers
+//!   let mut source = Source::default();
+//!   let t = t.instantiate(&ctx, &mut source);
+//!   assert_eq!(t.to_string(), "(t0 → bool) → list(t0) → list(t0)");
 //!
-//! // We can register a substitution for t0 in the context:
-//! ctx.extend(0, tp!(int));
-//! let t = t.apply(&ctx);
-//! assert_eq!(t.to_string(), "(int → bool) → list(int) → list(int)");
+//!   // We can register a substitution for t0 in the context:
+//!   let mut sub = Substitution::with_capacity(ctx, 32);
+//!   sub.add(Variable(0), tp!(ctx, int));
+//!   let t = t.apply(&sub);
+//!   assert_eq!(t.to_string(), "(int → bool) → list(int) → list(int)");
+//! })
 //! ```
 //!
 //! Extended example:
 //!
 //! ```
-//! use polytype::{ptp, tp, Context};
+//! use polytype::{ptp, tp, with_ctx, Context, Source, Type};
 //!
-//! // reduce: ∀α. ∀β. (β → α → β) → β → [α] → β
-//! // We can represent the type schema of reduce using the included macros:
-//! let t = ptp!(0, 1; @arrow[
-//!     tp!(@arrow[tp!(1), tp!(0), tp!(1)]),
-//!     tp!(1),
-//!     tp!(list(tp!(0))),
-//!     tp!(1),
-//! ]);
-//! assert_eq!(t.to_string(), "∀t0. ∀t1. (t1 → t0 → t1) → t1 → list(t0) → t1");
+//! with_ctx(32, |ctx| {
+//!     // reduce: ∀α. ∀β. (β → α → β) → β → [α] → β
+//!     let t = ptp!(ctx, 0, 1; @arrow[
+//!         tp!(ctx, @arrow[tp!(ctx, 1), tp!(ctx, 0), tp!(ctx, 1)]),
+//!         tp!(ctx, 1),
+//!         tp!(ctx, list(tp!(ctx, 0))),
+//!         tp!(ctx, 1),
+//!     ]);
+//!     assert_eq!(t.to_string(), "∀t0. ∀t1. (t1 → t0 → t1) → t1 → list(t0) → t1");
 //!
-//! // Let's consider reduce when applied to a function that adds two ints
+//!     // We also create a source of fresh type variables.
+//!     let mut src = Source::default();
 //!
-//! // First, we create a new typing context to manage typing bookkeeping.
-//! let mut ctx = Context::default();
+//!     // Consider reduce when applied to a function that adds two `ints`.
 //!
-//! // Let's create a type representing binary addition.
-//! let tplus = tp!(@arrow[tp!(int), tp!(int), tp!(int)]);
-//! assert_eq!(tplus.to_string(), "int → int → int");
+//!     // Let's create a type representing binary addition.
+//!     let tint = tp!(ctx, int);
+//!     let tplus = tp!(ctx, @arrow[tint, tint, tint]);
+//!     assert_eq!(tplus.to_string(), "int → int → int");
 //!
-//! // We instantiate the type schema of reduce within our context
-//! // so new type variables will be distinct
-//! let t = t.instantiate(&mut ctx);
-//! assert_eq!(t.to_string(), "(t1 → t0 → t1) → t1 → list(t0) → t1");
+//!     // We instantiate the type schema of reduce within our context
+//!     // so new type variables will be distinct
+//!     let t = t.instantiate(&ctx, &mut src);
+//!     assert_eq!(t.to_string(), "(t1 → t0 → t1) → t1 → list(t0) → t1");
 //!
-//! // By unifying, we can ensure function applications obey type requirements.
-//! let treturn = ctx.new_variable();
-//! let targ1 = ctx.new_variable();
-//! let targ2 = ctx.new_variable();
-//! ctx.unify(
-//!     &t,
-//!     &tp!(@arrow[
-//!         tplus.clone(),
-//!         targ1.clone(),
-//!         targ2.clone(),
-//!         treturn.clone(),
-//!     ]),
-//! ).expect("unifies");
+//!     // By unifying, we can ensure function applications obey type requirements.
+//!     let treturn = tp!(ctx, src.fresh());
+//!     let targ1 = tp!(ctx, src.fresh());
+//!     let targ2 = tp!(ctx, src.fresh());
+//!     let sub = Type::unify(&[(
+//!         t,
+//!         tp!(ctx, @arrow[
+//!             tplus,
+//!             targ1,
+//!             targ2,
+//!             treturn,
+//!         ])
+//!     )], &ctx).expect("unifies");
 //!
-//! // We can also now infer what arguments are needed and what gets returned
-//! assert_eq!(targ1.apply(&ctx), tp!(int));             // inferred arg 1: int
-//! assert_eq!(targ2.apply(&ctx), tp!(list(tp!(int))));  // inferred arg 2: list(int)
-//! assert_eq!(treturn.apply(&ctx), tp!(int));           // inferred return: int
+//!     // We can also now infer what arguments are needed and what gets returned
+//!     assert_eq!(targ1.apply(&sub), tint);                  // inferred arg 1: int
+//!     assert_eq!(targ2.apply(&sub), tp!(ctx, list(tint)));  // inferred arg 2: list(int)
+//!     assert_eq!(treturn.apply(&sub), tint);                // inferred return: int
 //!
-//! // Finally, we can see what form reduce takes by applying the new substitution
-//! let t = t.apply(&ctx);
-//! assert_eq!(t.to_string(), "(int → int → int) → int → list(int) → int");
+//!     // Finally, we can see what form reduce takes by applying the new substitution
+//!     let t = t.apply(&sub);
+//!     assert_eq!(t.to_string(), "(int → int → int) → int → list(int) → int");
+//! })
 //! ```
 //!
-//! [`Context`]: struct.Context.html
-//! [`Context::unify`]: struct.Context.html#method.unify
+//! [`ptp`]: macro.ptp.html
+//! [`tp`]: macro.tp.html
+//! [`Infer`]: trait.Infer.html
+//! [`Substitution`]: struct.Substitution.html
 //! [`Type`]: enum.Type.html
+//! [`Type::unify`]: enum.Type.html#method.unify
+//! [`TypeContext`]: struct.TypeContext.html
 //! [`TypeSchema::instantiate`]: enum.TypeSchema.html#method.instantiate
 //! [`TypeSchema`]: enum.TypeSchema.html
+//! [`Schema`]: type.Schema.html
+//! [`Ty`]: type.Ty.html
 //! [Hindley-Milner polymorphic typing system]: https://en.wikipedia.org/wiki/Hindley–Milner_type_system
 
 mod context;
 mod macros;
-#[cfg(feature = "parser")]
 mod parser;
+mod source;
+mod substitution;
 mod types;
 
-pub use context::{Context, ContextChange, UnificationError};
-pub use parser::ParseError;
-pub use types::{Type, TypeSchema, Variable};
+pub use context::{with_ctx, Context, TypeContext};
+pub use source::{Source, SourceChange};
+use std::hash::Hash;
+pub use substitution::{Snapshot, Substitution};
+pub use types::{Schema, Ty, Type, TypeSchema, UnificationError, Variable};
 
 /// Types require a `Name` for comparison.
 ///
@@ -119,30 +138,38 @@ pub use types::{Type, TypeSchema, Variable};
 /// Using static strings:
 ///
 /// ```
-/// # use polytype::Type;
-/// let t = Type::Constructed("int", vec![])
-/// # ;
+/// # use polytype::with_ctx;
+/// with_ctx(32, |ctx| {
+///     let tint = ctx.intern_tcon(ctx.intern_name("int"), &[]);
+/// })
 /// ```
 ///
 /// A custom implementation:
 ///
 /// ```
-/// # use polytype::{Type, Name};
-/// #[derive(Clone, PartialEq, Eq)]
+/// # use polytype::{with_ctx, Name};
+/// #[derive(Clone, PartialEq, Eq, Hash)]
 /// struct N(u8);
 ///
 /// impl Name for N {
+///     type ParseError = &'static str;
 ///     fn arrow() -> Self {
 ///         N(0)
 ///     }
+///     fn parse(s: &str) -> Result<Self, Self::ParseError> {
+///         s.parse::<u8>().map(|n| N(n)).or(Err("failed to parse Name"))
+///     }
 /// }
 ///
-/// let t: Type<N> = Type::Constructed(N(1), vec![])
-/// # ;
+/// with_ctx(32, |ctx| {
+///     let tint = ctx.intern_tcon(ctx.intern_name(N(1)), &[]);
+/// })
 /// ```
 ///
 /// [`arrow`]: #tymethod.arrow
-pub trait Name: Clone + Eq {
+pub trait Name: Clone + Eq + Hash {
+    /// A description of a failed `Name` parse.
+    type ParseError;
     /// A specific name representing an arrow must be declared.
     fn arrow() -> Self;
     /// A way of displaying the name.
@@ -153,15 +180,14 @@ pub trait Name: Clone + Eq {
     /// with [`show`].
     ///
     /// [`show`]: #method.show
-    fn parse(_s: &str) -> Result<Self, ParseError> {
-        Err(ParseError)
-    }
-
+    fn parse(s: &str) -> Result<Self, Self::ParseError>;
+    /// Returns `true` if the name represents an arrow, else `false`.
     fn is_arrow(&self) -> bool {
         *self == Self::arrow()
     }
 }
 impl Name for &'static str {
+    type ParseError = &'static str;
     /// The rightwards arrow in unicode: `→`.
     #[inline(always)]
     fn arrow() -> &'static str {
@@ -173,10 +199,10 @@ impl Name for &'static str {
     }
     /// **LEAKY** because it gives the string a static lifetime.
     #[inline(always)]
-    fn parse(s: &str) -> Result<&'static str, ParseError> {
+    fn parse(s: &str) -> Result<&'static str, Self::ParseError> {
         Ok(unsafe { &mut *Box::into_raw(s.to_string().into_boxed_str()) })
     }
-    /// The rightwards arrow in unicode: `→`.
+    /// Checks whether a name is the rightwards arrow in unicode: `→`.
     #[inline(always)]
     fn is_arrow(&self) -> bool {
         *self == "→"
@@ -190,30 +216,38 @@ impl Name for &'static str {
 /// In the simplest case, you statically know what the type is:
 ///
 /// ```
-/// use polytype::{tp, Infer, Type, UnificationError};
+/// use polytype::{tp, with_ctx, Infer, Ty, TypeContext, UnificationError};
 ///
 /// struct MyPrimitive;
-/// impl Infer<()> for MyPrimitive {
-///     fn infer(&self, _ctx: &()) -> Result<Type, UnificationError> {
-///         Ok(tp!(my_thing_tp))
+/// impl<'ctx> Infer<'ctx, TypeContext<'ctx>> for MyPrimitive {
+///     fn infer(&self, ctx: &TypeContext<'ctx>) -> Result<Ty<'ctx>, UnificationError<'ctx>> {
+///         Ok(tp!(ctx, my_thing_tp))
 ///     }
 /// }
 ///
-/// assert_eq!(MyPrimitive.infer(&()), Ok(tp!(my_thing_tp)));
+/// with_ctx(32, |ctx| {
+///     assert_eq!(MyPrimitive.infer(&ctx), Ok(tp!(ctx, my_thing_tp)));
+/// })
 /// ```
 ///
 /// A more complex case builds a new type given typed items.
 ///
 /// ```
-/// use polytype::{ptp, tp, Context, Infer, Type, TypeSchema, UnificationError};
+/// use polytype::{
+///     ptp, tp, with_ctx, Source, Substitution, Infer,
+///     Ty, Type, TypeContext, Schema, UnificationError
+/// };
 /// use std::cell::RefCell;
 ///
-/// type MyCtx = RefCell<Context>; // the RefCell allows us to mutate the context during inference
+/// // the RefCell allows us to mutate the context during inference
+/// type MyCtx<'ctx> = RefCell<(Source, TypeContext<'ctx>)>;
 ///
-/// struct Primitive(TypeSchema);
-/// impl Infer<MyCtx> for Primitive {
-///     fn infer(&self, ctx: &MyCtx) -> Result<Type, UnificationError> {
-///         Ok(self.0.instantiate(&mut ctx.borrow_mut()))
+/// struct Primitive<'ctx>(Schema<'ctx>);
+/// impl<'ctx> Infer<'ctx, MyCtx<'ctx>> for Primitive<'ctx> {
+///     fn infer(&self, ctx: &MyCtx<'ctx>) -> Result<Ty<'ctx>, UnificationError<'ctx>> {
+///         let mut inner = ctx.borrow_mut();
+///         let tctx = inner.1;
+///         Ok(self.0.instantiate(&tctx, &mut inner.0))
 ///     }
 /// }
 ///
@@ -221,28 +255,35 @@ impl Name for &'static str {
 ///     left: A,
 ///     right: B,
 /// }
-/// impl<A: Infer<MyCtx>, B: Infer<MyCtx>> Infer<MyCtx> for Application<A, B> {
-///     fn infer(&self, ctx: &MyCtx) -> Result<Type, UnificationError> {
+/// impl<'ctx, A, B> Infer<'ctx, MyCtx<'ctx>> for Application<A, B>
+///   where
+///     A: Infer<'ctx, MyCtx<'ctx>>,
+///     B: Infer<'ctx, MyCtx<'ctx>>
+/// {
+///     fn infer(&self, ctx: &MyCtx<'ctx>) -> Result<Ty<'ctx>, UnificationError<'ctx>> {
 ///         let ft = self.left.infer(ctx)?;
 ///         let xt = self.right.infer(ctx)?;
 ///         let mut ctx = ctx.borrow_mut();
-///         let ret = ctx.new_variable();
-///         ctx.unify(&ft, &Type::arrow(xt, ret.clone()))?;
-///         Ok(ret.apply(&ctx))
+///         let tctx = ctx.1;
+///         let ret = tp![tctx, ctx.0.fresh()];
+///         let sub = Type::unify(&[(ft, tctx.arrow(xt, ret))], &tctx)?;
+///         Ok(ret.apply(&sub))
 ///     }
 /// }
 ///
-/// let f = Primitive(ptp!(@arrow[tp!(foo), tp!(bar)]));
-/// let x = Primitive(ptp!(foo));
-/// let fx = Application { left: f, right: x };
-/// let ctx = RefCell::new(Context::default());
-/// assert_eq!(fx.infer(&ctx), Ok(tp!(bar)));
+/// with_ctx(32, |ctx| {
+///     let f = Primitive(ptp!(ctx, @arrow[tp!(ctx, foo), tp!(ctx, bar)]));
+///     let x = Primitive(ptp!(ctx, foo));
+///     let fx = Application { left: f, right: x };
+///     let c = RefCell::new((Source::default(), ctx));
+///     assert_eq!(fx.infer(&c), Ok(tp!(ctx, bar)));
+/// })
 /// ```
 ///
 /// A more sophisticated case has the types maintained externally:
 ///
 /// ```
-/// use polytype::{ptp, tp, Context, Infer, Type, TypeSchema, UnificationError};
+/// use polytype::{ptp, tp, with_ctx, Infer, Schema, Source, Substitution, Ty, Type, TypeContext, UnificationError, Variable};
 /// use std::{cell::RefCell, collections::HashMap};
 ///
 /// // in this example, every Term has a Type defined through the Lexicon
@@ -250,61 +291,67 @@ impl Name for &'static str {
 ///     GlobalVariable(u32),
 ///     Application { op: u32, args: Vec<Term> },
 /// }
-/// struct Lexicon {
-///     ctx: RefCell<Context>,
-///     ops: HashMap<u32, TypeSchema>,
-///     global_vars: RefCell<HashMap<u32, Type>>,
+/// struct Lexicon<'ctx> {
+///     src: RefCell<Source>,
+///     sub: RefCell<Substitution<'ctx>>,
+///     ctx: TypeContext<'ctx>,
+///     ops: HashMap<u32, Schema<'ctx>>,
+///     global_vars: RefCell<HashMap<u32, Ty<'ctx>>>,
 /// }
 ///
-/// impl Infer<Lexicon> for Term {
-///     fn infer(&self, lex: &Lexicon) -> Result<Type, UnificationError> {
+/// impl<'ctx> Infer<'ctx, Lexicon<'ctx>> for Term {
+///     fn infer(&self, lex: &Lexicon<'ctx>) -> Result<Ty<'ctx>, UnificationError<'ctx>> {
 ///         match self {
 ///             Term::GlobalVariable(v) => Ok(lex
 ///                 .global_vars
 ///                 .borrow_mut()
 ///                 .entry(*v)
-///                 .or_insert_with(|| lex.ctx.borrow_mut().new_variable())
-///                 .clone()),
+///                 .or_insert_with(|| lex.ctx.intern_tvar(Variable(lex.src.borrow_mut().fresh())))),
 ///             Term::Application { op, args } => {
-///                 let mut arg_types: Vec<Type> = args
+///                 let mut arg_types: Vec<Ty> = args
 ///                     .into_iter()
 ///                     .map(|arg| arg.infer(lex))
 ///                     .collect::<Result<Vec<_>, _>>()?;
-///                 let mut ctx = lex.ctx.borrow_mut();
-///                 let ret = ctx.new_variable();
-///                 arg_types.push(ret.clone());
-///                 let func_type = lex.ops[op].instantiate(&mut ctx);
-///                 ctx.unify(&func_type, &Type::from(arg_types))?;
-///                 Ok(ret.apply(&ctx))
+///                 let mut src = lex.src.borrow_mut();
+///                 let ret = lex.ctx.intern_tvar(Variable(src.fresh()));
+///                 arg_types.push(ret);
+///                 let func_type = lex.ops[op].instantiate(&lex.ctx, &mut src);
+///                 Type::unify_with_sub(&[(func_type, lex.ctx.arrow_slice(&arg_types))], &mut lex.sub.borrow_mut())?;
+///                 Ok(ret.apply(&lex.sub.borrow()))
 ///             }
 ///         }
 ///     }
 /// }
 ///
-/// let mut h = HashMap::new();
-/// h.insert(0, ptp!(0; @arrow[tp!(0), tp!(foo)]));
-/// h.insert(1, ptp!(@arrow[tp!(bar), tp!(baz)]));
-/// let lex = Lexicon {
-///     ctx: RefCell::new(Context::default()),
-///     ops: h,
-///     global_vars: RefCell::new(HashMap::new()),
-/// };
-/// let term = Term::Application {
-///     op: 0,
-///     args: vec![Term::Application {
-///         op: 1,
-///         args: vec![Term::GlobalVariable(42)],
-///     }],
-/// };
-/// assert_eq!(term.infer(&lex), Ok(tp!(foo)));
-/// assert_eq!(
-///     lex.global_vars
-///         .borrow()
-///         .get(&42)
-///         .map(|t| t.apply(&lex.ctx.borrow())),
-///     Some(tp!(bar))
-/// );
+/// with_ctx(32, |ctx| {
+///     let mut h = HashMap::new();
+///     h.insert(0, ptp!(ctx, 0; @arrow[tp!(ctx, 0), tp!(ctx, foo)]));
+///     h.insert(1, ptp!(ctx, @arrow[tp!(ctx, bar), tp!(ctx, baz)]));
+///     let lex = Lexicon {
+///         src: RefCell::new(Source::default()),
+///         sub: RefCell::new(Substitution::with_capacity(ctx, 32)),
+///         ops: h,
+///         global_vars: RefCell::new(HashMap::new()),
+///         ctx,
+///     };
+///     let term = Term::Application {
+///         op: 0,
+///         args: vec![Term::Application {
+///             op: 1,
+///             args: vec![Term::GlobalVariable(42)],
+///         }],
+///     };
+///     assert_eq!(term.infer(&lex), Ok(tp!(ctx, foo)));
+///     assert_eq!(
+///         lex.global_vars
+///             .borrow()
+///             .get(&42)
+///             .map(|t| t.apply(&lex.sub.borrow())),
+///         Some(tp!(ctx, bar))
+///     );
+/// })
 /// ```
-pub trait Infer<Context, E = UnificationError, N: Name = &'static str> {
-    fn infer(&self, ctx: &Context) -> Result<Type<N>, E>;
+pub trait Infer<'ctx, Context, E = UnificationError<'ctx>, N: Name = &'static str> {
+    /// Given a context, return a principal typing or fail.
+    fn infer(&self, ctx: &Context) -> Result<Ty<'ctx, N>, E>;
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,174 @@
+use crate::{Name, Schema, Ty, Type, TypeContext, TypeSchema, Variable};
+
+/// A way to generate fresh [`Variable`]s.
+///
+/// [`Variable`]: struct.Variable.html
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Source(pub(crate) usize);
+
+/// Allow types to be reified for use under a different [`Source`].
+///
+/// [`Source`]: struct.Source.html
+pub struct SourceChange {
+    pub(crate) delta: usize,
+    pub(crate) sacreds: Vec<Variable>,
+}
+
+impl Source {
+    /// Get a fresh bare [`Variable`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Source, TypeContext};
+    /// with_ctx(32, |ctx: TypeContext<'_>| {
+    ///   let mut src = Source::default();
+    ///   assert_eq!(src.fresh(), 0);
+    ///   assert_eq!(src.fresh(), 1);
+    ///   assert_eq!(src.fresh(), 2);
+    /// });
+    /// ```
+    ///
+    /// [`Variable`]: type.Variable.html
+    pub fn fresh(&mut self) -> usize {
+        let var = self.0;
+        self.0 += 1;
+        var
+    }
+    /// Combine two `Source`s.
+    ///
+    /// This merges `other` into `self` and produces a [`SourceChange`], which
+    /// can be used to transform the values produced by `other` to be consistent
+    /// with the state of `self` after the merge. Values passed in as `sacreds`
+    /// are considered to be shared between the two `Source`s.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Source, TypeContext, Variable};
+    /// with_ctx(32, |ctx: TypeContext<'_>| {
+    ///   let mut src_1 = Source::default();
+    ///   src_1.fresh();
+    ///   src_1.fresh();
+    ///   let mut src_2 = Source::default();
+    ///   src_2.fresh();
+    ///   src_2.fresh();
+    ///   let change = src_1.merge(src_2, vec![Variable(1)]);
+    ///   assert_eq!(src_1.fresh(), 4);
+    ///
+    ///   let t_original = tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx, 1)]);
+    ///   assert_eq!(t_original.to_string(), "t0 → t1");
+    ///
+    ///   let t_reified = change.reify_type(t_original, &ctx);
+    ///   assert_eq!(t_reified.to_string(), "t2 → t1");
+    /// });
+    /// ```
+    ///
+    /// [`Variable`]: type.Variable.html
+    pub fn merge(&mut self, other: Self, sacreds: Vec<Variable>) -> SourceChange {
+        let delta = self.0;
+        // this is intentionally wasting variable space when there are sacreds:
+        self.0 += other.0;
+        SourceChange { delta, sacreds }
+    }
+}
+
+impl Default for Source {
+    fn default() -> Self {
+        Source(0)
+    }
+}
+
+impl SourceChange {
+    /// Reify a [`Ty`] for use under a new [`Source`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Source, TypeContext, Variable};
+    /// with_ctx(32, |ctx: TypeContext<'_>| {
+    ///   let mut src_1 = Source::default();
+    ///   src_1.fresh();
+    ///   src_1.fresh();
+    ///   let mut src_2 = Source::default();
+    ///   src_2.fresh();
+    ///   src_2.fresh();
+    ///   let change = src_1.merge(src_2, vec![Variable(1)]);
+    ///   assert_eq!(src_1.fresh(), 4);
+    ///
+    ///   let t_original = tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx, 1)]);
+    ///   assert_eq!(t_original.to_string(), "t0 → t1");
+    ///
+    ///   let t_reified = change.reify_type(t_original, &ctx);
+    ///   assert_eq!(t_reified.to_string(), "t2 → t1");
+    /// });
+    /// ```
+    ///
+    /// [`Source`]: struct.Source.html
+    /// [`Ty`]: type.Ty.html
+    pub fn reify_type<'ctx, N: Name>(
+        &self,
+        tp: Ty<'ctx, N>,
+        ctx: &TypeContext<'ctx, N>,
+    ) -> Ty<'ctx, N> {
+        match *tp {
+            Type::Constructed(head, args) => {
+                let mut new_args = Vec::with_capacity(args.len());
+                for arg in args {
+                    new_args.push(self.reify_type(arg, ctx));
+                }
+                let new_args = ctx.intern_args(&new_args);
+                ctx.intern_tcon(head, new_args)
+            }
+            Type::Variable(n) if self.sacreds.contains(&n) => tp,
+            Type::Variable(n) => ctx.intern_tvar(Variable(n.0 + self.delta)),
+        }
+    }
+    /// Reify a [`TypeSchema`] for use under a new [`Source`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{ptp, tp, with_ctx, Source, TypeContext, Variable};
+    /// with_ctx(32, |ctx: TypeContext<'_>| {
+    ///   let mut src_1 = Source::default();
+    ///   src_1.fresh();
+    ///   src_1.fresh();
+    ///   src_1.fresh();
+    ///
+    ///   let mut src_2 = Source::default();
+    ///   src_2.fresh();
+    ///   src_2.fresh();
+    ///   src_2.fresh();
+    ///
+    ///   let change = src_1.merge(src_2, vec![Variable(1)]);
+    ///   assert_eq!(src_1.fresh(), 6);
+    ///
+    ///   let s_original = ptp!(ctx, 0, @arrow[
+    ///       tp!(ctx, @arrow[tp!(ctx, 0), tp!(ctx, 1)]),
+    ///       tp!(ctx, @arrow[tp!(ctx, 2), tp!(ctx, 1)])
+    ///   ]);
+    ///   assert_eq!(s_original.to_string(), "∀t0. (t0 → t1) → t2 → t1");
+    ///
+    ///   let s_reified = change.reify_typeschema(s_original, &ctx);
+    ///   assert_eq!(s_reified.to_string(), "∀t3. (t3 → t1) → t5 → t1");
+    /// });
+    /// ```
+    ///
+    /// [`Schema`]: type.Schema.html
+    /// [`Source`]: struct.Source.html
+    pub fn reify_typeschema<'ctx, N: Name>(
+        &self,
+        schema: Schema<'ctx, N>,
+        ctx: &TypeContext<'ctx, N>,
+    ) -> Schema<'ctx, N> {
+        match schema {
+            TypeSchema::Monotype(inner) => ctx.intern_monotype(self.reify_type(inner, ctx)),
+            TypeSchema::Polytype(variable, body) => {
+                let t_var = Variable(variable.0 + self.delta);
+                let new_body = self.reify_typeschema(body, ctx);
+                ctx.intern_polytype(t_var, new_body)
+            }
+        }
+    }
+}

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,4 +1,4 @@
-use crate::{Name, Schema, Ty, Type, TypeContext, TypeSchema, Variable};
+use crate::{Name, Schema, Substitution, Ty, Type, TypeContext, TypeSchema, Variable};
 
 /// A way to generate fresh [`Variable`]s.
 ///
@@ -169,6 +169,56 @@ impl SourceChange {
                 let new_body = self.reify_typeschema(body, ctx);
                 ctx.intern_polytype(t_var, new_body)
             }
+        }
+    }
+    /// Reify a [`Substitution`] for use under a new [`Source`].
+    ///
+    /// # Examples
+    /// ```
+    /// # use polytype::{ptp, tp, with_ctx, Source, Substitution, Type, TypeContext, Variable};
+    /// with_ctx(1024, |ctx| {
+    ///    let mut src = Source::default();
+    ///    let a = src.fresh();
+    ///    let b = src.fresh();
+    ///    let _ = src.fresh();
+    ///    let ta = ctx.intern_tvar(Variable(a));
+    ///    let tb = ctx.intern_tvar(Variable(b));
+    ///    let t1 = ctx.arrow(ta, tb);
+    ///    let t2 = tp!(ctx, @arrow[tp!(ctx, int), tp!(ctx, bool)]);
+    ///    let sub1 = Type::unify(&[(t1, t2)], &ctx).unwrap();
+    ///
+    ///    let mut src2 = Source::default();
+    ///    let _ = src2.fresh();
+    ///    let pt = ptp!(ctx, 0, 1; @arrow[tp!(ctx, 0), tp!(ctx, 1)]);
+    ///    let t = pt.instantiate(&ctx, &mut src2);
+    ///    let last = ctx.intern_tvar(Variable(src2.fresh()));
+    ///    let mut sub2 = Substitution::with_capacity(ctx, 32);
+    ///    sub2.add(Variable(2), tp!(ctx, bool));
+    ///
+    ///    let src_change = src.merge(src2, vec![Variable(0), Variable(1)]);
+    ///    let t_reified = src_change.reify_type(t, &ctx);
+    ///    assert_eq!(t_reified.to_string(), "t1 → t5");
+    ///    src_change.reify_substitution(&mut sub2, &ctx);
+    ///    assert_eq!(
+    ///        t_reified.apply(&sub2).apply(&sub1).to_string(),
+    ///        "bool → bool"
+    ///    );
+    /// })
+    ///```
+    ///
+    /// [`Substitution`]: struct.Substitution.html
+    /// [`Source`]: struct.Source.html
+    pub fn reify_substitution<'ctx, N: Name>(
+        &self,
+        sub: &mut Substitution<'ctx, N>,
+        ctx: &TypeContext<'ctx, N>,
+    ) {
+        for (var, tp) in sub.sub.iter_mut() {
+            let contains_var = self.sacreds.contains(var);
+            if !contains_var {
+                *var = Variable(var.0 + self.delta)
+            }
+            *tp = self.reify_type(tp, ctx);
         }
     }
 }

--- a/src/substitution.rs
+++ b/src/substitution.rs
@@ -1,0 +1,274 @@
+use crate::{Name, Ty, TypeContext, Variable};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+/// A way to mark the current state of a [`Substitution`] such that it can be later restored.
+///
+/// [`Substitution`]: struct.Substitution.html
+pub struct Snapshot(usize);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+/// A mapping from [`Variable`]s to [`Ty`]s indicating that each [`Variable`]
+/// can be substituted for the corresponding [`Ty`].
+///
+/// [`Variable`]: struct.Variable.html
+/// [`Ty`]: type.Ty.html
+pub struct Substitution<'ctx, N: Name = &'static str> {
+    /// The `TypeContext` in which typing takes place.
+    pub(crate) ctx: TypeContext<'ctx, N>,
+    /// The `Variable` to `Ty` map.
+    pub(crate) sub: Vec<(Variable, Ty<'ctx, N>)>,
+}
+
+pub struct SubIter<'a, 'ctx, N: Name = &'static str> {
+    it: std::slice::Iter<'a, (Variable, Ty<'ctx, N>)>,
+}
+pub struct SubIterMut<'a, 'ctx, N: Name = &'static str> {
+    it: std::slice::IterMut<'a, (Variable, Ty<'ctx, N>)>,
+}
+
+impl<'ctx, N: Name> Substitution<'ctx, N> {
+    /// Construct an empty `Substitution` with at least capacity for `n` mappings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext};
+    /// with_ctx(32, |ctx: TypeContext<'_>| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   assert_eq!(sub.len(), 0);
+    /// });
+    /// ```
+    pub fn with_capacity(ctx: TypeContext<'ctx, N>, n: usize) -> Self {
+        Substitution {
+            ctx,
+            sub: Vec::with_capacity(n),
+        }
+    }
+    /// Optionally retrieve the [`Ty`] associated with some variable.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, Variable, Type};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   sub.add(Variable(0), tp!(ctx, int));
+    ///   assert_eq!( sub.get(Variable(0)), Some(tp!(ctx, int)));
+    ///   assert_eq!(sub.get(Variable(1)), None)
+    /// });
+    /// ```
+    pub fn get(&self, q: Variable) -> Option<Ty<'ctx, N>> {
+        self.sub.iter().find(|(k, _)| *k == q).map(|(_, v)| *v)
+    }
+    /// Insert a new mapping into the `Substitution` unless it conflicts with an
+    /// existing mapping.
+    ///
+    /// The return value indicates whether the insertion was successful.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   assert_eq!(sub.len(), 0);
+    ///   let added = sub.add(Variable(0), tp!(ctx, int));
+    ///   assert!(added);
+    ///   assert_eq!(sub.len(), 1);
+    ///   let added = sub.add(Variable(0), tp!(ctx, bool));
+    ///   assert!(!added);
+    ///   assert_eq!(sub.len(), 1);
+    /// });
+    /// ```
+    pub fn add(&mut self, k: Variable, v: Ty<'ctx, N>) -> bool {
+        if self.sub.iter().any(|(j, _)| k == *j) {
+            false
+        } else {
+            self.sub.push((k, v));
+            true
+        }
+    }
+    /// The `Substitution` as a slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   sub.add(Variable(0), tp!(ctx, int));
+    ///   sub.add(Variable(1), tp!(ctx, bool));
+    ///   let slice = sub.as_slice();
+    ///   assert_eq!(slice.len(), 2);
+    ///   assert_eq!(slice[0], (Variable(0), tp!(ctx, int)));
+    ///   assert_eq!(slice[1], (Variable(1), tp!(ctx, bool)));
+    /// });
+    /// ```
+    pub fn as_slice(&self) -> &[(Variable, Ty<'ctx, N>)] {
+        &self.sub
+    }
+    /// An Iterator over the `Substitution`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   sub.add(Variable(0), tp!(ctx, int));
+    ///   sub.add(Variable(1), tp!(ctx, bool));
+    ///   sub.add(Variable(2), tp!(ctx, bool));
+    ///   sub.add(Variable(3), tp!(ctx, char));
+    ///   sub.add(Variable(4), tp!(ctx, bool));
+    ///   assert_eq!(sub.iter().filter(|(v, t)| *t == tp!(ctx, bool)).count(), 3);
+    /// });
+    /// ```
+    pub fn iter<'a>(&'a self) -> SubIter<'a, 'ctx, N> {
+        SubIter {
+            it: self.sub.iter(),
+        }
+    }
+    /// A mutable Iterator over the `Substitution`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   sub.add(Variable(0), tp!(ctx, int));
+    ///   sub.add(Variable(1), tp!(ctx, bool));
+    ///   sub.add(Variable(2), tp!(ctx, bool));
+    ///   sub.add(Variable(3), tp!(ctx, char));
+    ///   sub.add(Variable(4), tp!(ctx, bool));
+    ///   assert_eq!(sub.iter().filter(|(v, t)| *t == tp!(ctx, bool)).count(), 3);
+    ///   for (v, t) in sub.iter_mut() {
+    ///       *t = tp!(ctx, bool);
+    ///   }
+    ///   assert_eq!(sub.iter().filter(|(v, t)| *t == tp!(ctx, bool)).count(), 5);
+    /// });
+    /// ```
+    pub fn iter_mut<'a>(&'a mut self) -> SubIterMut<'a, 'ctx, N> {
+        SubIterMut {
+            it: self.sub.iter_mut(),
+        }
+    }
+    /// The number of constraints in the `Substitution`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   sub.add(Variable(0), tp!(ctx, int));
+    ///   sub.add(Variable(1), tp!(ctx, bool));
+    ///   sub.add(Variable(2), tp!(ctx, float));
+    ///   sub.add(Variable(3), tp!(ctx, char));
+    ///   sub.add(Variable(4), tp!(ctx, string));
+    ///   assert_eq!(sub.len(), 5);
+    /// });
+    /// ```
+    pub fn len(&self) -> usize {
+        self.sub.len()
+    }
+    /// `true` if the `Substitution` has any constraints, else `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(32, |ctx| {
+    ///   let mut sub = Substitution::with_capacity(ctx, 10);
+    ///   assert!(sub.is_empty());
+    ///   sub.add(Variable(0), tp!(ctx, int));
+    ///   assert!(!sub.is_empty());
+    /// });
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.sub.is_empty()
+    }
+    /// Clears the substitution managed by the context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Substitution, TypeContext, Variable};
+    /// with_ctx(10, |ctx: TypeContext<'_>| {
+    ///     let mut sub = Substitution::with_capacity(ctx, 1);
+    ///
+    ///     let clean = sub.clone();
+    ///
+    ///     sub.add(Variable(0), tp!(ctx, int));
+    ///     let dirty = sub.clone();
+    ///
+    ///     sub.clean();
+    ///
+    ///     assert_eq!(clean, sub);
+    ///     assert_ne!(clean, dirty);
+    /// })
+    /// ```
+    pub fn clean(&mut self) {
+        self.sub.clear();
+    }
+    /// Creates a `Snapshot` to which the `Substitution` can be rolled back.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Snapshot, Substitution, TypeContext, Variable};
+    /// with_ctx(10, |ctx: TypeContext<'_>| {
+    ///     let mut sub = Substitution::with_capacity(ctx, 5);
+    ///     sub.add(Variable(0), tp!(ctx, int));
+    ///     sub.add(Variable(1), tp!(ctx, bool));
+    ///     sub.add(Variable(2), tp!(ctx, char));
+    ///     let snapshot = sub.snapshot();
+    ///     assert_eq!(sub.len(), 3);
+    ///     sub.add(Variable(3), tp!(ctx, bool));
+    ///     sub.add(Variable(4), tp!(ctx, char));
+    ///     assert_eq!(sub.len(), 5);
+    ///     sub.rollback(snapshot);
+    ///     assert_eq!(sub.len(), 3);
+    /// })
+    /// ```
+    pub fn snapshot(&self) -> Snapshot {
+        Snapshot(self.len())
+    }
+    /// Removes all substitutions added to the `Substitution` since the supplied `Snapshot`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use polytype::{tp, with_ctx, Snapshot, Substitution, TypeContext, Variable};
+    /// with_ctx(10, |ctx: TypeContext<'_>| {
+    ///     let mut sub = Substitution::with_capacity(ctx, 5);
+    ///     sub.add(Variable(0), tp!(ctx, int));
+    ///     sub.add(Variable(1), tp!(ctx, bool));
+    ///     sub.add(Variable(2), tp!(ctx, char));
+    ///     let snapshot = sub.snapshot();
+    ///     assert_eq!(sub.len(), 3);
+    ///     sub.add(Variable(3), tp!(ctx, bool));
+    ///     sub.add(Variable(4), tp!(ctx, char));
+    ///     assert_eq!(sub.len(), 5);
+    ///     sub.rollback(snapshot);
+    ///     assert_eq!(sub.len(), 3);
+    /// })
+    /// ```
+    pub fn rollback(&mut self, Snapshot(n): Snapshot) {
+        self.sub.truncate(n)
+    }
+}
+
+impl<'a, 'ctx, N: Name> Iterator for SubIter<'a, 'ctx, N> {
+    type Item = &'a (Variable, Ty<'ctx, N>);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next()
+    }
+}
+
+impl<'a, 'ctx, N: Name> Iterator for SubIterMut<'a, 'ctx, N> {
+    type Item = &'a mut (Variable, Ty<'ctx, N>);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next()
+    }
+}


### PR DESCRIPTION
This is a full-scale rewrite of `polytype` to use interned names and types in order to improve efficiency.